### PR TITLE
enable hyde

### DIFF
--- a/autorag/data_builder/generate_synthetic_query.py
+++ b/autorag/data_builder/generate_synthetic_query.py
@@ -35,13 +35,16 @@ def main(cfg: DictConfig):
 
     llm = OpenAI(model="gpt-4")
     if prompt_template_path:
-        with open(prompt_template_path, 'r', encoding='utf-8') as f:
-            qa_generate_prompt_tmpl = f.read().strip('\n')
+        with open(prompt_template_path, "r", encoding="utf-8") as f:
+            qa_generate_prompt_tmpl = f.read().strip("\n")
     else:
         qa_generate_prompt_tmpl = DEFAULT_QA_GENERATE_PROMPT_TMPL
     print(qa_generate_prompt_tmpl)
     qa_dataset = generate_question_context_pairs(
-        selected_nodes, llm=llm, qa_generate_prompt_tmpl=qa_generate_prompt_tmpl, num_questions_per_chunk=num_questions_per_chunk
+        selected_nodes,
+        llm=llm,
+        qa_generate_prompt_tmpl=qa_generate_prompt_tmpl,
+        num_questions_per_chunk=num_questions_per_chunk,
     )
     output_dir = os.path.dirname(output_path)
     os.makedirs(output_dir, exist_ok=True)

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -6,7 +6,7 @@ indexer:
 data_builder:
   generate_synthetic_query:
     index_dir: ${indexer.build.index_dir} 
-    prompt_template_path: data/${app_name}/synthetic_data/generate_synthetic_query_prompt_template.txt
+    prompt_template_path: data/${app_name}/synthetic_data/qa_gen_tmpl.txt
     output_path: data/${app_name}/synthetic_data/synthetic_queries.json
     random_seed: 0
     from_num_nodes: 2
@@ -28,6 +28,7 @@ synthesizer:
   render:
     index_dir: ${indexer.build.index_dir}
     app_description: ${app_name}
+    enable_hyde: true
     citation_cfg:
       enable_cite: true
       citation_chunk_size: 512


### PR DESCRIPTION
Enable hyde in synthesizer demo. More details [here](https://docs.llamaindex.ai/en/stable/examples/query_transformations/HyDEQueryTransformDemo.html). When enabled, before giving the final response, the chatbot will first generate the answer using LLM without the database and then use the generated answer to do retrieval. In the demo, the non-RAG answer will be shown along with the RAG answer for comparison. 